### PR TITLE
feat(cron): synchronize sports events daily

### DIFF
--- a/apps/bot/src/app/cron/index.ts
+++ b/apps/bot/src/app/cron/index.ts
@@ -5,6 +5,7 @@ import * as birthdayJob from './birthday.job';
 import * as dailyShopJob from './daily-shop.job';
 import * as gameReleaseJob from './game-release.job';
 import * as sportJob from './sport-notifications.job';
+import * as sportSyncJob from './sport-sync.job';
 
 function setupCron(discordClient: Client) {
   const jobs = [
@@ -32,6 +33,13 @@ function setupCron(discordClient: Client) {
     new CronJob(
       gameReleaseJob.cronTiming,
       () => gameReleaseJob.cronDefinition(),
+      null,
+      true,
+      'Europe/Paris'
+    ),
+    new CronJob(
+      sportSyncJob.cronTiming,
+      () => sportSyncJob.cronDefinition(),
       null,
       true,
       'Europe/Paris'

--- a/apps/bot/src/app/cron/sport-sync.job.ts
+++ b/apps/bot/src/app/cron/sport-sync.job.ts
@@ -1,0 +1,37 @@
+import { prisma } from '@discord-bot-v2/prisma';
+import { exec } from 'child_process';
+import { promisify } from 'util';
+
+const asyncExec = promisify(exec);
+
+export const cronTiming = '0 55 23 * * *';
+
+export async function cronDefinition() {
+  try {
+    const syncConfig = await prisma.config.findUniqueOrThrow({
+      where: {
+        name: 'SPORT_SYNC',
+      },
+    });
+
+    const configValue = syncConfig.value as Array<{
+      sport: string;
+      year: number;
+    }>;
+    const commands = configValue.map((config) =>
+      asyncExec(
+        `node ./dist/cli/main.js generate-sport-events --sport ${config.sport} --year ${config.year}`
+      )
+    );
+
+    await Promise.all(commands).then((output) => {
+      output.forEach(({ stdout, stderr }) => {
+        console.log('STDOUT ->', stdout);
+        console.log('STDERR ->', stderr);
+      });
+    });
+  } catch (err) {
+    console.error('Error while synchronizing the sports data');
+    console.error(err);
+  }
+}

--- a/libs/prisma/src/migrations/20230502112453_add_sport_config/migration.sql
+++ b/libs/prisma/src/migrations/20230502112453_add_sport_config/migration.sql
@@ -1,0 +1,3 @@
+-- This is an empty migration.
+
+INSERT INTO Config (name, value) VALUES ('SPORT_SYNC', '[{"sport": "football", "year": 2022},{"sport": "nba", "year": 2022}]');


### PR DESCRIPTION
Add a daily job to run the CLI commands. It will synchronize the events. It's pretty useful for dynamic competitions like the playoff in NBA or in the champions league where the dates and teams are based on the result earlier in the tree